### PR TITLE
fix: 修复右键删除节点后连线 label 跳号的问题

### DIFF
--- a/src/components/flow/nodes/utils/nodeOperations.tsx
+++ b/src/components/flow/nodes/utils/nodeOperations.tsx
@@ -141,6 +141,26 @@ export function saveNodeAsTemplate(
  */
 export function deleteNode(nodeId: string): void {
   const flowStore = useFlowStore.getState();
+  const { instance, edges } = flowStore;
+
+  if (instance) {
+    const nodeToDelete = flowStore.nodes.find((n) => n.id === nodeId);
+    if (nodeToDelete) {
+      void instance.deleteElements({ nodes: [nodeToDelete], edges: [] });
+      return;
+    }
+  }
+
+  const connectedEdgeIds = edges
+    .filter((edge) => edge.source === nodeId || edge.target === nodeId)
+    .map((edge) => edge.id);
+
+  if (connectedEdgeIds.length > 0) {
+    flowStore.updateEdges(
+      connectedEdgeIds.map((id) => ({ id, type: "remove" as const })),
+    );
+  }
+
   flowStore.updateNodes([{ type: "remove", id: nodeId }]);
 }
 

--- a/src/components/flow/nodes/utils/nodeOperations.tsx
+++ b/src/components/flow/nodes/utils/nodeOperations.tsx
@@ -139,14 +139,14 @@ export function saveNodeAsTemplate(
  * 删除节点（通用工具函数）
  * @param nodeId 节点ID
  */
-export function deleteNode(nodeId: string): void {
+export async function deleteNode(nodeId: string): Promise<void> {
   const flowStore = useFlowStore.getState();
   const { instance, edges } = flowStore;
 
   if (instance) {
     const nodeToDelete = flowStore.nodes.find((n) => n.id === nodeId);
     if (nodeToDelete) {
-      void instance.deleteElements({ nodes: [nodeToDelete], edges: [] });
+      await instance.deleteElements({ nodes: [nodeToDelete] });
       return;
     }
   }


### PR DESCRIPTION
## Summary
  - 修复右键删除节点后，连线 label 编号出现跳号的问题

  ## Changes
  - `src/components/flow/nodes/utils/nodeOperations.tsx` — 删除节点时重新计算连线 label，确保编号连续
