### PR TITLE
docs: 修复 README 中失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,4 +147,4 @@ MPE 项目没有单独的交流群，您可以在 MaaFramework 集成/开发交�
 - `2025.5-8`：[MNMA](https://github.com/kqcoxn/MaaNewMoonAccompanying) 实践（思路修补）
 - `2025.5`：[YaMaaPE](https://github.com/kqcoxn/YAMaaPE)（项目原型）
 
-[![Star History Chart](https://api.star-history.com/svg?repos=kqcoxn/MaaPipelineEditor&type=Date)](https://www.star-history.com/#kqcoxn/MaaPipelineEditor&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=kqcoxn/MaaPipelineEditor&type=Date)](https://star-history.dera.page/#kqcoxn/MaaPipelineEditor&Date)


### PR DESCRIPTION
README 中的 Star History 图表当前已失效，无法正常加载展示项目星标历史。原因是现有数据源受 GitHub 接口限制影响。

此改动将图表切换到稳定的新数据源 star-history.dera.page，恢复图表功能，让读者能正常查看项目的星标变化情况。